### PR TITLE
feat: Support caching an authentication token in the local filesystem

### DIFF
--- a/cmd/checktoken/README.md
+++ b/cmd/checktoken/README.md
@@ -1,0 +1,24 @@
+checktoken
+==========
+
+Do various operations on the cached authenticaation token, which must
+be generated/saved with the gettoken command.  The actual function of
+this program depends on a single command word given after any flags
+such as `-json`.
+
+check
+-----
+Check the timestamp validity of the cached token.  Process return
+code 0 if the cached token is valid according to the timestamps, 1
+otherwise.
+
+clear
+-----
+Clear the cache.  This operation does not invalidate the token, so if
+the bearer token exists anywhere else (in a file, etc.) it can still
+be used for vehicle access.
+
+print
+-----
+Print the authentication bearer token, or the complete token structure
+if the `-json` flag is given.

--- a/cmd/checktoken/main.go
+++ b/cmd/checktoken/main.go
@@ -1,0 +1,137 @@
+//
+// Copyright (C) 2019 Bruce A. Mah.
+// All rights reserved.
+//
+// Distributed under a BSD-style license, see the LICENSE file for
+// more information.
+//
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"gotesla"
+	"os"
+)
+
+var jsonOutput bool = false
+
+// Return true if the cached token is valid, false otherwise
+func checkCached() bool {
+
+	// Try to read the cached token. If it doesn't exist,
+	// clearly that's invalid.
+	t, err := gotesla.LoadCachedToken()
+	if err != nil {
+		fmt.Println(err)
+		return false
+	}
+
+	// Check validity
+	return gotesla.CheckToken(t)
+}
+
+// Print token object in JSON representation
+func printCached() {
+	t, err := gotesla.LoadCachedToken()
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	
+	// Output just the token, or the entire JSON structure as appropriate
+	if jsonOutput {
+		b, err := json.Marshal(*t)
+		if err != nil {
+			fmt.Println(err)
+			return
+		}
+		os.Stdout.Write(b)
+	} else {
+		fmt.Printf("%s\n", t.AccessToken)
+	}
+
+}
+
+// Delete the cached token
+func deleteCached() {
+	err := gotesla.DeleteCachedToken()
+	if err != nil {
+		fmt.Println(err)
+	}
+}
+
+func main() {
+	var verbose bool = false
+
+	// Command-line arguments
+	flag.BoolVar(&verbose, "verbose", false, "Verbose output")
+	flag.BoolVar(&jsonOutput, "json", false, "JSON output")
+
+	// XXX define new flag.Usage() so we can print the valid commands
+	
+	// Parse command-line arguments
+	flag.Parse()
+	
+	// We need exactly one word after any arguments...it's a command
+	if flag.NArg() != 1 {
+		fmt.Println("Need exactly one command")
+		return
+	}
+
+	// Commands are:
+	// check, delete, print
+	switch flag.Arg(0) {
+
+		// check
+		// Check the validity of the cached token
+		case "check": {
+			if checkCached() == false {
+				// XXX find a more graceful way to exit
+				os.Exit(1)
+			}
+		}
+
+		case "clear":
+		deleteCached()
+
+		// print
+		// Print the cached token in JSON representation
+		case "print":
+		printCached()
+
+		default:
+		fmt.Println("Invalid command")
+
+	}
+
+/*
+	// Don't verify TLS certs...
+	tls := &tls.Config{InsecureSkipVerify: true}
+	
+	// Get TLS transport
+	tr := &http.Transport{TLSClientConfig: tls}
+	
+	// Make an HTTPS client
+	client := &http.Client{Transport: tr}
+	
+	// Get an authentication token
+	t, err := gotesla.GetAndCacheToken(client, email, password)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	// Output just the token, or the entire JSON structure as appropriate
+	if *jsonOutput {
+		b, err := json.Marshal(*t)
+		if err != nil {
+			fmt.Println(err)
+		}
+		os.Stdout.Write(b)
+	} else {
+		fmt.Printf("%s\n", t.AccessToken)
+	}
+*/
+}

--- a/cmd/checktoken/main.go
+++ b/cmd/checktoken/main.go
@@ -42,7 +42,7 @@ func printCached() {
 	
 	// Output just the token, or the entire JSON structure as appropriate
 	if jsonOutput {
-		b, err := json.Marshal(*t)
+		b, err := json.MarshalIndent(*t, "", "    ")
 		if err != nil {
 			fmt.Println(err)
 			return

--- a/cmd/gettoken/README.md
+++ b/cmd/gettoken/README.md
@@ -6,6 +6,13 @@ Obtains an authentication token from Tesla API servers.
 Pass MyTesla account credentials using the `-email` and `-password`
 options.
 
-Returns the Tesla bearer token, which is required for most other API
-calls.  To see the entire token JSON structure (including the
-expiration and renewal fields), also pass the `-json` flag.
+The authentication token, which is passed as a parameter in Tesla API
+calls, is saved in the file ~/.gotesla.cache.  This is the place where
+other gotesla utilities will expect to find an authentication token;
+with the exception of gettoken they generally do not have the means to
+generate a new token on their own.
+
+This utility also prints the Tesla bearer token.  To see the entire
+token JSON structure (including the expiration and renewal fields),
+also pass the `-json` flag.  After the token has been generated, the
+checktoken utility can also be used to examine the cached token.

--- a/cmd/gettoken/README.md
+++ b/cmd/gettoken/README.md
@@ -3,8 +3,15 @@ gettoken
 
 Obtains an authentication token from Tesla API servers.
 
-Pass MyTesla account credentials using the `-email` and `-password`
-options.
+There are two modes of operation.  The first is a straightforward
+login, using an owner's MyTesla account credentials.  Pass these using
+the `-email` and `-password` options.  Tokens are valid for about 45
+days.
+
+The other mode of operation is to refresh an existing token, before it
+expires.  This allows a user's login session to extend much longer
+than the 45-day lifetime of a token.  To refresh a token, pass the
+`-refresh` command-line flag.
 
 The authentication token, which is passed as a parameter in Tesla API
 calls, is saved in the file ~/.gotesla.cache.  This is the place where

--- a/cmd/gettoken/main.go
+++ b/cmd/gettoken/main.go
@@ -23,6 +23,7 @@ func main() {
 	// Command-line arguments
 	var email = flag.String("email", "", "MyTesla email address")
 	var password = flag.String("password", "", "MyTesla account password")
+	var refresh = flag.Bool("refresh", false, "Refresh existing cached token")
 	var jsonOutput = flag.Bool("json", false, "Print token JSON")
 	flag.BoolVar(&verbose, "verbose", false, "Verbose output")
 
@@ -38,13 +39,32 @@ func main() {
 	// Make an HTTPS client
 	client := &http.Client{Transport: tr}
 	
-	// Get an authentication token
-	t, err := gotesla.GetAndCacheToken(client, email, password)
-	if err != nil {
-		fmt.Println(err)
+	var t *gotesla.Token
+	var err error
+
+	// We either are doing a refresh (where refresh == true) or
+	// we're doing a fresh login and we need a username and password
+	if *refresh {
+		var t0 *gotesla.Token
+		t0, err = gotesla.LoadCachedToken()
+		if err != nil {
+			fmt.Println(err)
+			return
+		}
+		t, err = gotesla.RefreshAndCacheToken(client, t0)
+	} else if len(*email) > 0 && len(*password) > 0 {
+
+		// Get an authentication token
+		t, err = gotesla.GetAndCacheToken(client, email, password)
+		if err != nil {
+			fmt.Println(err)
+			return
+		}
+	} else {
+		fmt.Println("Either -refresh needs to be set, or furnish both -email and -password")
 		return
 	}
-
+	
 	// Output just the token, or the entire JSON structure as appropriate
 	if *jsonOutput {
 		b, err := json.MarshalIndent(*t, "", "    ")

--- a/cmd/gettoken/main.go
+++ b/cmd/gettoken/main.go
@@ -47,7 +47,7 @@ func main() {
 
 	// Output just the token, or the entire JSON structure as appropriate
 	if *jsonOutput {
-		b, err := json.Marshal(*t)
+		b, err := json.MarshalIndent(*t, "", "    ")
 		if err != nil {
 			fmt.Println(err)
 		}

--- a/cmd/gettoken/main.go
+++ b/cmd/gettoken/main.go
@@ -39,7 +39,7 @@ func main() {
 	client := &http.Client{Transport: tr}
 	
 	// Get an authentication token
-	t, err := gotesla.GetToken(client, email, password)
+	t, err := gotesla.GetAndCacheToken(client, email, password)
 	if err != nil {
 		fmt.Println(err)
 		return
@@ -47,7 +47,7 @@ func main() {
 
 	// Output just the token, or the entire JSON structure as appropriate
 	if *jsonOutput {
-		b, err := json.Marshal(t)
+		b, err := json.Marshal(*t)
 		if err != nil {
 			fmt.Println(err)
 		}

--- a/cmd/scimport/README.md
+++ b/cmd/scimport/README.md
@@ -8,6 +8,9 @@ then dumps these measurements into an InfluxDB database.  One can then
 use something like Grafana to visualize time-series measurements of
 Supercharger occupancy.
 
+This program requires that a cached authentication token be created
+using the gettoken utility.
+
 This code has some issues because as of this writing, the community
 version of InfluxDB is in flux, and it might be difficult to build the
 required InfluxDB golang client library.  I've found this to work:
@@ -17,9 +20,6 @@ required InfluxDB golang client library.  I've found this to work:
     % git clone https://github.com/influxdata/influxdb.git
     % git checkout 1.7
     % go get github.com/influxdata/influxdb/client/v2
-
-Use the `-token` flag to specify a Tesla authentication token (can be
-created using the gettoken utility, or by any other means).
 
 Use the `-influx-url`, `-influx-database`, and `-influx-measurement` flags
 to specify where to write the data.  The defaults are to write a

--- a/cmd/scimport/main.go
+++ b/cmd/scimport/main.go
@@ -35,7 +35,6 @@ func main() {
 	rand.Seed(time.Now().UTC().UnixNano())
 	
 	// Command-line arguments
-	flag.StringVar(&BearerToken, "token", "", "Tesla authentication token")
 	flag.StringVar(&InfluxUrl, "influx-url", "http://localhost:8086",
 		"Influx database server URL")
 	flag.StringVar(&InfluxDb, "influx-database", "tesla",
@@ -47,6 +46,14 @@ func main() {
 	// Parse command-line arguments
 	flag.Parse()
 	
+	// Get cached Tesla authentication token
+	token, err := gotesla.LoadCachedToken()
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	var BearerToken = token.AccessToken
+
 	// Don't verify TLS certs...
 	tls := &tls.Config{InsecureSkipVerify: true}
 	

--- a/cmd/scimport/main.go
+++ b/cmd/scimport/main.go
@@ -20,9 +20,6 @@ import (
 	influxClient "github.com/influxdata/influxdb/client/v2" // too many things called "client"
 )
 
-// Authentication for Tesla API
-var BearerToken string
-
 // InfluxDB parameters
 var InfluxUrl string
 var InfluxDb string
@@ -52,7 +49,6 @@ func main() {
 		fmt.Println(err)
 		return
 	}
-	var BearerToken = token.AccessToken
 
 	// Don't verify TLS certs...
 	tls := &tls.Config{InsecureSkipVerify: true}
@@ -64,7 +60,7 @@ func main() {
 	client := &http.Client{Transport: tr}
 	
 	// Get vehicles list
-	vr, err := gotesla.GetVehicles(client, BearerToken)
+	vr, err := gotesla.GetVehicles(client, token)
 	if err != nil {
 		fmt.Println(err)
 		return
@@ -90,7 +86,7 @@ func main() {
 				fmt.Printf("Vehicle: id %d VIN %s\n", v.Id, v.Vin)
 			}
 
-			nc, err := gotesla.GetNearbyChargers(client, BearerToken, v.Id)
+			nc, err := gotesla.GetNearbyChargers(client, token, v.Id)
 			if err != nil {
 				fmt.Println(err)
 				return

--- a/gotesla.go
+++ b/gotesla.go
@@ -59,7 +59,7 @@ type Token struct {
 // Authenticate with Tesla servers and get a bearer token.
 //
 func GetToken(client *http.Client, username *string, password *string) (*Token, error) {
-	var verbose bool = true
+	var verbose bool = false
 	
 	// Auth is an authorization structure for the Tesla API.
 	// Field names need to begin with capital letters for the JSON

--- a/gotesla.go
+++ b/gotesla.go
@@ -217,7 +217,7 @@ func TokenTimes(t *Token) (start, end time.Time) {
 //
 // General Tesla API request
 //
-func GetTesla(client *http.Client, bearerToken string, endpoint string) ([]byte, error) {
+func GetTesla(client *http.Client, token *Token, endpoint string) ([]byte, error) {
 	var verbose bool = false
 	
 	// Figure out the correct endpoint
@@ -234,7 +234,9 @@ func GetTesla(client *http.Client, bearerToken string, endpoint string) ([]byte,
 	req.Header.Add("User-Agent", UserAgent)
 	req.Header.Add("Content-Type", "application/json")
 	req.Header.Add("Accept", "application/json")
-	req.Header.Add("Authorization", "Bearer " + bearerToken)
+	if token != nil {
+		req.Header.Add("Authorization", "Bearer " + token.AccessToken)
+	}
 
 	if verbose {
 		fmt.Printf("Headers: %s\n", req.Header)
@@ -287,11 +289,11 @@ type VehiclesResponse struct {
 	Count int `json:"count"`
 }
 
-func GetVehicles(client *http.Client, bearerToken string) (VehiclesResponse, error) {
+func GetVehicles(client *http.Client, token *Token) (VehiclesResponse, error) {
 	var verbose = false
 	var vr VehiclesResponse
 
-	vehiclejson, err := GetTesla(client, bearerToken, "/api/1/vehicles")
+	vehiclejson, err := GetTesla(client, token, "/api/1/vehicles")
 	if err != nil {
 		return vr, err
 	}
@@ -341,11 +343,11 @@ type NearbyChargingSitesResponse struct {
 	}
 }
 
-func GetNearbyChargers(client *http.Client, bearerToken string, id int) (NearbyChargingSitesResponse, error) {
+func GetNearbyChargers(client *http.Client, token *Token, id int) (NearbyChargingSitesResponse, error) {
 	var verbose = false
 	var ncsr NearbyChargingSitesResponse
 
-	vehiclejson, err := GetTesla(client, bearerToken, "/api/1/vehicles/" + strconv.Itoa(id) + "/nearby_charging_sites")
+	vehiclejson, err := GetTesla(client, token, "/api/1/vehicles/" + strconv.Itoa(id) + "/nearby_charging_sites")
 	if err != nil {
 		return ncsr, err
 	}


### PR DESCRIPTION
We want to cache authentication tokens locally in the filesystem in order to avoid hitting Tesla's authentication servers for every new program and also to avoid having users come up with random, ad hoc ways of storing tokens.

Because we store the entire JSON response (rather than just the bearer token) we can do things like refresh tokens and display bits of metadata from the cached token.  We also avoid having client programs having to grovel around inside the Token structure.

We've also generalized a bit of the POST logic so it can be used in the future for other operations.
